### PR TITLE
Support initial state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,19 @@
-export default (...reducers) => (prevState, value, ...args) =>
-  reducers.reduce(
-    (newState, reducer) => reducer(newState, value, ...args),
-    prevState
-  );
+export default (...args) => {
+  const initialState =
+    typeof args[args.length - 1] !== 'function' && args.pop();
+  const reducers = args;
+
+  if (typeof initialState === 'undefined') {
+    throw new TypeError(
+      'The initial state may not be undefined. If you do not want to set a value for this reducer, you can use null instead of undefined.'
+    );
+  }
+
+  return (prevState, value, ...args) =>
+    typeof prevState === 'undefined'
+      ? initialState
+      : reducers.reduce(
+          (newState, reducer) => reducer(newState, value, ...args),
+          prevState
+        );
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,24 @@
 import reduceReducers from '../src';
 
+test('returns initialState', () => {
+  const initialState = { A: 0, B: 0 };
+  const reducer = reduceReducers(
+    (state, payload) => ({
+      ...state,
+      A: state.A + payload
+    }),
+    initialState
+  );
+
+  expect(reducer()).toEqual(initialState);
+});
+
+test('throws an error if initialState is undefined', () => {
+  expect(() => {
+    reduceReducers(undefined);
+  }).toThrow();
+});
+
 test('combines multiple reducers into a single reducer', () => {
   const reducer = reduceReducers(
     (state, payload) => ({ ...state, A: state.A + payload }),


### PR DESCRIPTION
Closes #9 

**Problem**

When initializing a state with `reducer(undefined)`:

```js
const reducer = reduceReducers(
  (state = { A: 0 }, payload) => ({ ...state, A: state.A + payload }),
  (state = { B: 0 }, payload) => ({ ...state, B: state.A * payload })
)

const initialState = reducer(undefined)
```

`initialState` will be:

```js
{ A: NaN, B: NaN }
```

There are few workaround for this problem, but none of them are convenient enough and just add additional boilerplate/code.

**Solution**

Passing `initialState` as last argument to `reducerReducers` and returning it if `undefined` has been passed as `state` to `reducer`. Why last argument and not first? If we would add it as first argument, it would break the current API and means we have to release a new major version and there would be a lots of error and changes needed in existing codebases. The goal is to make it optional for everyone without breaking anything and using `initialState` if needed.

```js
const reducer = reduceReducers(
  (state, payload) => ({ ...state, A: state.A + payload }),
  (state, payload) => ({ ...state, B: state.A * payload }),
  { A: 0, B: 0}
)
```

How does it work under the hood? `reduceReducers` will check if the last value in the arguments array is not a function and uses that as `initialState`. That way we are supporting all kind of possible values and not limiting to objects only.

