### PR TITLE
initialState should be optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default (...args) => {
   }
 
   return (prevState, value, ...args) =>
-    typeof prevState === 'undefined'
+    typeof (prevState === 'undefined') && initialState
       ? initialState
       : reducers.reduce(
           (newState, reducer) => reducer(newState, value, ...args),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,3 +52,24 @@ test('supports additional arguments', () => {
 
   expect(reducerAddMult({ A: 1, B: 2 }, 3, 2)).toEqual({ A: 48, B: 2 });
 });
+
+test('no initialState supplied + undefined state: single reducer', () => {
+  const addReducer = (state = { A: 1, B: 2 }, payload) => ({
+    ...state,
+    A: state.A + payload
+  });
+  const reducer = reduceReducers(addReducer);
+
+  expect(reducer(undefined, 42)).toEqual(addReducer(undefined, 42));
+});
+
+test('no initialState supplied + undefined state: initial state defined by first reducer', () => {
+  const aReducer = (state = { A: 1, B: 2 }, payload) => ({
+    ...state,
+    A: state.A + payload
+  });
+  const bReducer = (state, payload) => ({ ...state, A: state.A * payload });
+  const reducerAB = reduceReducers(aReducer, bReducer);
+
+  expect(reducerAB(undefined, 3)).toEqual({ A: 12, B: 2 });
+});


### PR DESCRIPTION
Since v0.4.0 we are able to supply initialState as a last argument to reduceReducers. But at the same time we lost the ability to define initial state by first reducer in the chain.

If I have some reducer called myReducer (that cares about setting default state if recieved state=undefined) I would expect that newReducer = reduceReducers(myReducer) would be functionally equivalent to myReducer. But now newReducer(undefined, someAction) returns 'false', while myReducer(undefined, someAction) returns some default state, defined by myReducer

This pull request solves this issue. 