### PR TITLE
Fix typeof call to return a proper value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default (...args) => {
   }
 
   return (prevState, value, ...args) => {
-    const prevStateIsUndefined = typeof (prevState === 'undefined');
+    const prevStateIsUndefined = typeof prevState === 'undefined';
     const valueIsUndefined = typeof value === 'undefined';
 
     if (prevStateIsUndefined && valueIsUndefined && initialState) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,3 +86,22 @@ test('no initialState supplied + undefined state: initial state defined by first
 
   expect(reducerAB(undefined, 3)).toEqual({ A: 12, B: 2 });
 });
+
+test('actions should progressively update state', () => {
+  const reducerA = (state, action) => {
+    if (action.type === 'A') return { ...state, a: true };
+    return state;
+  };
+  const reducerB = (state, action) => {
+    if (action.type === 'B') return { ...state, b: true };
+    return state;
+  };
+  const initial = { a: false, b: false };
+  const combined = reduceReducers(reducerA, reducerB, initial);
+
+  let state = combined(undefined, { type: 'A' });
+  expect(state).toEqual({ a: true, b: false });
+
+  state = combined(state, { type: 'B' });
+  expect(state).toEqual({ a: true, b: true });
+});


### PR DESCRIPTION
The previous expression`typeof (prevState === 'undefined')` returns the value `'boolean'` since the `typeof (...)` evaluates the expression of `prevState === 'undefined'` which is `true` thus returning `'boolean'`.

Instead, simply compare `typeof prevState === 'undefined'` which resolves to `true/false` as expected (removed the parens `()`).

Added a test suite to verify multiple actions called on a reducer work as expected, which wasn't previously tested.

Fixes the issue I reported [here](https://github.com/redux-utilities/reduce-reducers/pull/17#issuecomment-406493531)

Issue introduced in #17