### PR TITLE
Added an error message if an undefined reducer was passed in

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,13 @@ export default (...args) => {
     }
 
     return reducers.reduce(
-      (newState, reducer) => reducer(newState, value, ...args),
+      (newState, reducer, index) => {
+        if (typeof reducer === 'undefined') {
+          throw new TypeError(`An undefined reducer was passed in at index ${index}`);
+        }
+
+        return reducer(newState, value, ...args);
+      },
       prevStateIsUndefined && !valueIsUndefined && initialState
         ? initialState
         : prevState

--- a/src/index.js
+++ b/src/index.js
@@ -17,17 +17,14 @@ export default (...args) => {
       return initialState;
     }
 
-    return reducers.reduce(
-      (newState, reducer, index) => {
-        if (typeof reducer === 'undefined') {
-          throw new TypeError(`An undefined reducer was passed in at index ${index}`);
-        }
+    return reducers.reduce((newState, reducer, index) => {
+      if (typeof reducer === 'undefined') {
+        throw new TypeError(
+          `An undefined reducer was passed in at index ${index}`
+        );
+      }
 
-        return reducer(newState, value, ...args);
-      },
-      prevStateIsUndefined && !valueIsUndefined && initialState
-        ? initialState
-        : prevState
-    );
+      return reducer(newState, value, ...args);
+    }, prevStateIsUndefined && !valueIsUndefined && initialState ? initialState : prevState);
   };
 };


### PR DESCRIPTION
Sometimes ES6 modules don't get resolved properly (especially when re-exporting ES6 modules with `export * from '...'`). In this case an undefined reducer might be passed in.

Example:

```js
import reducerA from './reducerA';
import reducerB from './reducerB';

const reducer = reduceReducers(
  reducerA,
  reducerB,
  initialState,
);
```

Currently the error is rather cryptic:
```
TypeError: Cannot read property 'apply' of undefined
```