### PR TITLE
index.d.ts default export typo fixed. #30

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,4 +7,4 @@ type Reducer<S> = (state: S, action: Action) => S;
 function reduceReducers<S>(initialState: S | null, ...reducers: Reducer<S>[]): Reducer<S>;
 function reduceReducers<S>(...reducers: Reducer<S>[]): Reducer<S>;
 
-export default reduceReducer;
+export default reduceReducers;


### PR DESCRIPTION
Fix for #30 . Looks like the overloads for #29 were named correctly but the export was left incorrectly singular.