### PR TITLE
Update typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,12 +2,12 @@ type Action = {
   type: string;
 };
 
-type Reducer<S> = (state: S, action: Action) => S;
+type Reducer<S, A extends Action> = (state: S, action: A) => S;
 
-export default function reduceReducers<S>(
-  initialState: S | null,
-  ...reducers: Reducer<S>[]
-): Reducer<S>;
-export default function reduceReducers<S>(
-  ...reducers: Reducer<S>[]
-): Reducer<S>;
+export default function reduceReducers<S, A extends Action>(
+  initialState: S | null | undefined,
+  ...reducers: Reducer<S, A>[]
+): Reducer<S, A>;
+export default function reduceReducers<S, A extends Action>(
+  ...reducers: Reducer<S, A>[]
+): Reducer<S, A>;


### PR DESCRIPTION
I'm trying to pass result of `reduceReducers` into `createStore` and it fails in typescript because of two issues:

- `createStore` expects initial store type to be `S | undefined` instead of `S | null`.
- `Action` aren't allowed to have fields except `type`.

**Example code:**

```
import reduceReducers from '../reduce-reducers';
import {createStore} from 'redux';

const reducer = (state: {}, action: {type: string, payload:any}) => {
  return {};
}

const result = reduceReducers(reducer);

const store = createStore(result);

```