### PR TITLE
fix typing: allows Action to be subset of Strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-type Action = {
-  type: string;
+type Action<T extends string> = {
+  type: T;
 };
 
 type Reducer<S> = (state: S, action: Action) => S;


### PR DESCRIPTION
This allows Action to be Subset of string. Earlier this used to throw an error as Action can be any string.