### PR TITLE
Hotfix #33 generic action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ es
 lib
 .DS_Store
 *.log
+.idea/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,14 @@
-type Action = {
-  type: string;
+type Action<T = any> = {
+  type: T;
 };
 
-type Reducer<S> = (state: S, action: Action) => S;
+type Reducer<S, A extends Action> = (state: S, action: A) => S;
 
-export default function reduceReducers<S>(
-  initialState: S | null,
-  ...reducers: Reducer<S>[]
-): Reducer<S>;
-export default function reduceReducers<S>(
-  ...reducers: Reducer<S>[]
-): Reducer<S>;
+export default function reduceReducers<S, A extends Action>(
+  initialState?: S,
+  ...reducers: Reducer<S, A>[]
+): Reducer<S, A>;
+
+export default function reduceReducers<S, A extends Action>(
+  ...reducers: Reducer<S, A>[]
+): Reducer<S, A>;


### PR DESCRIPTION
Fix for #33 generalizes `Action` type.

To specify custom action type:

1. Create new `NewAction` type with desired shape by extending provided `Action` type and passing in new `NEW_TYPE_NAME` type:

   ```typescript
   interface NewAction extends Action<NEW_TYPE_NAME> {
     payload: any;
   }
   ```

2. Use `reduce-reducers` as before, but pass in `NewAction`, second type parameter:

   ```typescript
   import reduceReducers from 'reduce-reducers';
   
   const initialState = { A: 0, B: 0 };
   
   const rootReducer = reduceReducers<NewState, NewAction>(
     initialState,
     addReducer,
     multReducer
   );
   ```

Your `rootReducer` is ready.