### PR TITLE
Improve types to support reducers with and without default handling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,12 +2,21 @@ type Action = {
   type: string;
 };
 
-type Reducer<S> = (state: S, action: Action) => S;
+type Reducer<S> = (state: S | undefined, action: Action) => S;
+type PreloadedReducer<S> = (state: S, action: Action) => S;
 
 export default function reduceReducers<S>(
-  initialState: S | null,
-  ...reducers: Reducer<S>[]
+  initialState: S,
+  ...reducers: PreloadedReducer<S>[]
 ): Reducer<S>;
 export default function reduceReducers<S>(
-  ...reducers: Reducer<S>[]
+  initialReducer: Reducer<S>,
+  ...reducers: PreloadedReducer<S>[]
 ): Reducer<S>;
+export default function reduceReducers<S>(
+  initialState: S | null,
+  ...reducers: PreloadedReducer<S>[]
+): PreloadedReducer<S>;
+export default function reduceReducers<S>(
+  ...reducers: PreloadedReducer<S>[]
+): PreloadedReducer<S>;


### PR DESCRIPTION
An attempt to unify original reducers as defined by redux project (takes `undefined` as state argument, named `Reducer`) and the way reducers were defined here (does not take `udnefined` as state argument, renamed to `PreloadedReducer`). Please note that a `PreloadedReducer` is always a `Reducer` as well. The types return the more general `Reducer` where possible.

It handles the following use cases I could come up with:

* with `initialState` (removed `null`) returning a `Reducer`
* with `initialState` (as before with `null`), returning a `PreloadedReducer` (Personally don't see much value in this one. Maybe add another option with `intialState` and `Reducer` as second argument?)
* `Reducer` as first argument injecting the default state, returning a `Reducer`
* only `PreloadedReducer`s, returning a `PreloadedReducer`

I am not sure whether type inference is working the way it was before for all use cases. In my project (one `Reducer` and multiple `PreloadedReducer`) type inference worked as expected. I could build some additional test cases if required.

Naming of `PreloadedReducer` could be improved.

Related to pull request #39. Decided to redefine Reducer for now.