### PR TITLE
Accept falsy initalValue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export default (...args) => {
-  const initialState = typeof args[0] !== 'function' && args.shift();
+  const initialState = typeof args[0] !== 'function' ? args.shift() : null;
   const reducers = args;
 
   if (typeof initialState === 'undefined') {
@@ -12,18 +12,23 @@ export default (...args) => {
     const prevStateIsUndefined = typeof prevState === 'undefined';
     const valueIsUndefined = typeof value === 'undefined';
 
-    if (prevStateIsUndefined && valueIsUndefined && initialState) {
+    if (prevStateIsUndefined && valueIsUndefined && initialState != null) {
       return initialState;
     }
 
-    return reducers.reduce((newState, reducer, index) => {
-      if (typeof reducer === 'undefined') {
-        throw new TypeError(
-          `An undefined reducer was passed in at index ${index}`
-        );
-      }
+    return reducers.reduce(
+      (newState, reducer, index) => {
+        if (typeof reducer === 'undefined') {
+          throw new TypeError(
+            `An undefined reducer was passed in at index ${index}`
+          );
+        }
 
-      return reducer(newState, value, ...args);
-    }, prevStateIsUndefined && !valueIsUndefined && initialState ? initialState : prevState);
+        return reducer(newState, value, ...args);
+      },
+      prevStateIsUndefined && !valueIsUndefined && initialState != null
+        ? initialState
+        : prevState
+    );
   };
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,6 +20,13 @@ test('passes `initialState` when state is `undefined` and value is defined', () 
   expect(reducer(undefined, 1)).toEqual({ A: 1, B: 0 });
 });
 
+test('passes falsy `initialState` when state is `undefined` and value is defined', () => {
+  const initialState = '';
+  const reducer = reduceReducers(initialState, (state, payload) => state);
+
+  expect(reducer(undefined, 1)).toEqual('');
+});
+
 test('throws an error if initialState is undefined', () => {
   expect(() => {
     reduceReducers(undefined);


### PR DESCRIPTION
When `initalValue` is falsy it was ignored.